### PR TITLE
Feature: use fanc meta from neck connective repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     magrittr,
     bit64,
     usethis,
+    data.table,
     methods
 Suggests: 
     malevnc (> 0.3.1),

--- a/R/meta.R
+++ b/R/meta.R
@@ -173,7 +173,7 @@ manc_meta <- function(ids, ...) {
 fanc_meta <- function(ids=NULL, ...) {
   ids=fanc_ids(ids)
   df=fancr::with_fanc(fancorbanc_meta(table='neuron_information', ids=ids, ...))
-  metaf=getOption('coconatfly.fancmeta')
+  metaf=getOption('coconatfly.fanc_meta')
   if(!is.null(metaf)) {
     # we can use an unevaluated call as an option
     # by evaluating we can trigger function

--- a/R/meta.R
+++ b/R/meta.R
@@ -172,7 +172,28 @@ manc_meta <- function(ids, ...) {
 
 fanc_meta <- function(ids=NULL, ...) {
   ids=fanc_ids(ids)
-  fancr::with_fanc(fancorbanc_meta(table='neuron_information', ids=ids, ...))
+  df=fancr::with_fanc(fancorbanc_meta(table='neuron_information', ids=ids, ...))
+  metaf=getOption('coconatfly.fancmeta')
+  if(!is.null(metaf)) {
+    ext=tools::file_ext(metaf)
+    df2=if(ext=='tsv') {
+      data.table::fread(metaf, integer64 = 'character')
+    } else if(ext=='feather') {
+      arrow::read_feather(metaf)
+    } else stop("Unsupported extension:", ext, " for FANC metadata file!")
+
+    df2$root_id=fancr::with_fanc(fafbseg::flywire_updateids(df2$root_id, df2$supervoxel_id, version = fanc_version()))
+    df2 <- df2 |>
+      rename(id=root_id) |>
+      select(-supervoxel_id, -cell_id)
+    df=dplyr::bind_rows(df2, df)
+    df <- df |>
+      filter(!duplicated(id))
+    if(length(ids)>0) {
+      df <- left_join(data.frame(id=ids), df, by='id')
+    }
+  }
+  df
 }
 
 banc_meta <- function(ids=NULL, ...) {

--- a/R/meta.R
+++ b/R/meta.R
@@ -203,6 +203,7 @@ fanc_meta <- function(ids=NULL, ...) {
       df <- left_join(data.frame(id=ids), df, by='id')
     }
   }
+  df$side=sub("HS|idline$", "", df$side)
   df
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,10 @@
+.onLoad <- function(libname, pkgname) {
+  # set up experimental extra
+  coconatfly.fanc_meta=getOption('coconatfly.fanc_meta')
+  if(is.null(coconatfly.fanc_meta)) {
+    options(coconatfly.fanc_meta=function() {
+      fafbseg::flywire_sirepo_file_memo('https://github.com/flyconnectome/2023neckconnective/blob/dev/data/fanc-neckconnective-anns.tsv', read=TRUE)
+    })
+  }
+  invisible()
+}


### PR DESCRIPTION
specifically from https://github.com/flyconnectome/2023neckconnective/blob/dev/data/fanc-neckconnective-anns.tsv

This should get us going with fanc-manc matching. But it is also possible to use another local source by setting `options(coconatfly.fanc_meta)`. This can be specified either as a function or a path to a local file on disk.

```R
options(coconatfly.fanc_meta=function() {
      fafbseg::flywire_sirepo_file_memo('https://github.com/flyconnectome/2023neckconnective/blob/dev/data/fanc-neckconnective-anns.tsv', read=TRUE)
    })
```

note that the use of an _anonymous_ `function` will delay evaluation of what is in inside the function until the option is queried. In this case flywire_sirepo_file_memo will update a local copy of the file from github if required.

```R
options(coconatfly.fanc_meta='~/flyconnectome/data/fanc-neckconnective-anns.tsv')
```


