### PR TITLE
WIP: clustering, drop partner neurons with type=NA

### DIFF
--- a/R/coconatfly-package.R
+++ b/R/coconatfly-package.R
@@ -1,5 +1,25 @@
 #' @keywords internal
 #' @import nat
+#' @section Package options:
+#'
+#' coconatfly itself currently only has one option, which is to use a historical
+#' behaviour for collating cell types for multi-connectome cosine clustering.
+#'
+#' \itemize{
+#'
+#' \item \code{options(coconatfly.cluster.dropna)}
+#'
+#' }
+#'
+#' @examples
+#' # list any package options that have been set
+#' options()[grepl("^coconatfly.*", names(options()))]
+#'
+#' # return to behaviour of coconatfly < v0.2
+#' options(coconatfly.cluster.dropna=FALSE)
+#' # return to default behaviour of coconatfly >= v0.2
+#' options(coconatfly.cluster.dropna=TRUE)
+#'
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/R/partners.R
+++ b/R/partners.R
@@ -127,7 +127,11 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
 #   different datasets so that when cell types are found in the dataset but
 #   missing from the partners we can use that negative result.
 # partners argument is just used to construct a warning message
-match_types <- function(x, group="type", partners="", min_datasets=Inf) {
+# historically drop.na was FALSE but I think should have been TRUE
+# We allow users to revert to the old behaviour using:
+# options("coconatfly.cluster.dropna")
+match_types <- function(x, group="type", partners="", min_datasets=Inf,
+                        drop.na=getOption("coconatfly.cluster.dropna", TRUE)) {
   stopifnot(is.data.frame(x))
   if(!is.finite(min_datasets)) min_datasets=dplyr::n_distinct(x$dataset)
 
@@ -135,6 +139,13 @@ match_types <- function(x, group="type", partners="", min_datasets=Inf) {
     dplyr::group_by_at(group) %>%
     dplyr::mutate(nd=dplyr::n_distinct(dataset)) %>%
     dplyr::ungroup()
+  if(drop.na) {
+    xg <- xg %>%
+      dplyr::mutate(nd=case_when(
+        is.na(.data[[group]]) ~ 0,
+        T ~ nd
+      ))
+  }
   todrop <- xg %>%
     dplyr::filter(nd<min_datasets)
   message("Matching types across datasets. Dropping ",

--- a/man/coconatfly-package.Rd
+++ b/man/coconatfly-package.Rd
@@ -8,6 +8,29 @@
 \description{
 Experimental package to enable comparative connectomics analysis of multiple Drosophila connectomics datasets, including some private ones still under development.
 }
+\section{Package options}{
+
+
+coconatfly itself currently only has one option, which is to use a historical
+behaviour for collating cell types for multi-connectome cosine clustering.
+
+\itemize{
+
+\item \code{options(coconatfly.cluster.dropna)}
+
+}
+}
+
+\examples{
+# list any package options that have been set
+options()[grepl("^coconatfly.*", names(options()))]
+
+# return to behaviour of coconatfly < v0.2
+options(coconatfly.cluster.dropna=FALSE)
+# return to default behaviour of coconatfly >= v0.2
+options(coconatfly.cluster.dropna=TRUE)
+
+}
 \seealso{
 Useful links:
 \itemize{


### PR DESCRIPTION
* leaving NA types presumably adds some noise; it could be argued that this is a good thing if it leads to lumping cells when a lot of partner neurons cannot be identified
* I anticipate that merging this will change a lot of across dataset clustering slightly
* need to check impact on single dataset clustering (grouped vs ungrouped)
* there should be a pathway to revert to previous behaviour – should think about whether this should be via an option (already an implemented), an explicit function argument or both