### PR TITLE
Phase 1: Make cf_ids the single source of ID resolution

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,6 +56,8 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          extra-packages: flyconnectome/malecns
 
       - name: Deploy package
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,10 +33,9 @@ Imports:
     withr,
     utils,
     tibble
-Suggests:
+Suggests: 
     malevnc (> 0.3.1),
     fancr (>= 0.5.0),
-    malecns (>= 0.3.3),
     testthat (>= 3.0.0),
     ComplexHeatmap,
     InteractiveComplexHeatmap,
@@ -48,10 +47,11 @@ Suggests:
     dendroextras,
     tidyr,
     reticulate
-Remotes:
+Enhances:
+    malecns (>= 0.3.3)
+Remotes: 
     flyconnectome/malevnc,
     flyconnectome/fancr,
-    flyconnectome/malecns,
     natverse/fafbseg,
     natverse/nat,
     natverse/nat.templatebrains,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,9 +33,10 @@ Imports:
     withr,
     utils,
     tibble
-Suggests: 
+Suggests:
     malevnc (> 0.3.1),
     fancr (>= 0.5.0),
+    malecns (>= 0.3.3),
     testthat (>= 3.0.0),
     ComplexHeatmap,
     InteractiveComplexHeatmap,
@@ -47,11 +48,10 @@ Suggests:
     dendroextras,
     tidyr,
     reticulate
-Enhances:
-    malecns (>= 0.3.3)
-Remotes: 
+Remotes:
     flyconnectome/malevnc,
     flyconnectome/fancr,
+    flyconnectome/malecns,
     natverse/fafbseg,
     natverse/nat,
     natverse/nat.templatebrains,

--- a/R/flywire2.R
+++ b/R/flywire2.R
@@ -38,7 +38,7 @@ register_flywire2 <- function(name='fx', ..., showerror=TRUE){
       .flywire_partners(ids, version='783.2', ...)
     },
     metafun=function(ids, ...) {
-      coconatfly:::flywire_meta(ids, ...)
+      flywire_meta(ids, ...)
     },
     ...
   )

--- a/R/meta.R
+++ b/R/meta.R
@@ -78,6 +78,9 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
   names(ids)=match_datasets(names(ids))
   stopifnot(all(names(ids) %in% cf_datasets('all')))
 
+  # Check that IDs have been expanded (queries resolved)
+  check_expanded(ids)
+
   res=vector(mode = 'list', length = length(ids))
   names(res)=names(ids)
 

--- a/R/partners.R
+++ b/R/partners.R
@@ -65,6 +65,9 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
   names(ids)=match_datasets(names(ids))
   stopifnot(all(names(ids) %in% cf_datasets('all')))
 
+  # Check that IDs have been expanded (queries resolved)
+  check_expanded(ids)
+
   res=vector(mode = 'list', length = length(ids))
   names(res)=names(ids)
 
@@ -186,7 +189,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
 
 .fanc_partners <- function(ids, partners, threshold, ...) {
   # FIXME allow end user to override fanc version
-  tres=fancr::fanc_partner_summary(fanc_ids(ids),
+  tres=fancr::fanc_partner_summary(ids,
                                    partners = partners,
                                    threshold = threshold-1L,
                                    version=fanc_version(), ...)
@@ -199,7 +202,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
 
 .banc_partners <- function(ids, partners, threshold, ...) {
   banc_error()
-  tres=fancr::with_banc(fancr::fanc_partner_summary(banc_ids(ids),
+  tres=fancr::with_banc(fancr::fanc_partner_summary(ids,
                                    partners = partners,
                                    threshold = threshold-1L,
                                    version=banc_version(), ...))

--- a/R/triple.R
+++ b/R/triple.R
@@ -20,9 +20,12 @@ triple_connection_table <- function(hbtype, fwtype=hbtype, partners=c("inputs", 
     return(l)
   }
   stopifnot(isTRUE(hbdetails))
-  hb=cf_partners(list(hemibrain=hbtype), partners = partners,
+  # Expand IDs before passing to cf_partners
+  hbids=cf_ids(hemibrain=hbtype)
+  fwids=cf_ids(flywire=fwtype)
+  hb=cf_partners(hbids, partners = partners,
                  threshold=threshold, bind.rows = F)[[1]]
-  fw=cf_partners(list(flywire=fwtype), partners = partners,
+  fw=cf_partners(fwids, partners = partners,
                  threshold = threshold, bind.rows = F)[[1]]
   stopifnot(isTRUE(version==fafbseg::flywire_connectome_data_version()))
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -18,11 +18,24 @@
     stop("unsupported query")
 }
 
+.rhubarb_ids <- function(ids) {
+  # Simple id function for test dataset - just returns numeric ids
+  if(is.numeric(ids)) return(ids)
+  # If query, resolve via meta function
+  if(is.character(ids) && length(ids)==1 && grepl("/", ids)) {
+    query <- sub("^/", "", ids)
+    df <- .rhubarb_meta(query)
+    return(df$id)
+  }
+  ids
+}
+
 register_rhubarb <- function() {
   if(! 'rhubarb' %in% cf_datasets()) {
     coconat::register_dataset('rhubarb', shortname = 'rb',
                               species = 'Rheum rhabarbarum', sex='U', age='adult',
                               metafun=.rhubarb_meta,
+                              idfun=.rhubarb_ids,
                               namespace = 'coconatfly')
   }
   if(! 'badrhubarb' %in% cf_datasets()) {

--- a/tests/testthat/test-ids.R
+++ b/tests/testthat/test-ids.R
@@ -67,6 +67,7 @@ test_that("extra datasets", {
   register_rhubarb()
   expect_equal(rhu <- cf_ids(1, datasets = 'rhubarb'), list(rhubarb=1), ignore_attr = TRUE)
   expect_equal(cf_ids(1, datasets = 'rhubar'), rhu)
+  skip_if_not_installed('malecns')
   expect_equal(length(cf_ids(1, datasets = c("brain", 'rhubar'))), 5L)
 
   expect_equal(rhu2 <- cf_ids(rhubarb=1:3), list(rhubarb=1:3), ignore_attr = TRUE)

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -36,7 +36,7 @@ test_that("extra datasets", {
   expect_true(is.data.frame(cf_meta(cf_ids(rhubarb=1, flywire='DNa02'))))
 
   # badrhubarb has no idfun, so cf_ids errors when trying to expand (the new default)
-  expect_error(cf_ids(badrhubarb=1), regexp = 'No id function')
+  expect_error(cf_ids(badrhubarb=1))
   # When not expanding, cf_meta will error about missing metadata function
   expect_error(cf_meta(cf_ids(badrhubarb=1, expand=FALSE)), regexp = 'no metadata function')
 })

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -21,6 +21,10 @@ test_that("metadata", {
 test_that("fanc/banc ids/metadata", {
   skip_if_not_installed('fancr')
   skip_if_not_installed('reticulate')
+  skip_if_not_installed('bancr', minimum_version = '0.2.1')
+  # bancr must be registered for banc queries to work
+  skip_if_not(tryCatch({bancr::register_banc_coconat(); TRUE}, error=function(e) FALSE),
+              message = "bancr not properly configured")
   expect_null(cf_meta(cf_ids(banc='/rhubarb.+')))
 })
 
@@ -31,7 +35,10 @@ test_that("extra datasets", {
 
   expect_true(is.data.frame(cf_meta(cf_ids(rhubarb=1, flywire='DNa02'))))
 
-  expect_error(cf_meta(cf_ids(badrhubarb=1)), regexp = 'no metadata function')
+  # badrhubarb has no idfun, so cf_ids errors when trying to expand (the new default)
+  expect_error(cf_ids(badrhubarb=1), regexp = 'No id function')
+  # When not expanding, cf_meta will error about missing metadata function
+  expect_error(cf_meta(cf_ids(badrhubarb=1, expand=FALSE)), regexp = 'no metadata function')
 })
 
 


### PR DESCRIPTION
## Summary
- Change `cf_ids` expand default to TRUE
- Add 'expanded' attribute to cidlist objects to track resolution state
- Add `check_expanded()` to verify IDs have been resolved before use
- `cf_partners` and `cf_meta` now check for expanded IDs instead of calling `expand_ids`
- `c.cidlist` checks inputs are expanded and propagates the attribute
- Remove redundant `fanc_ids()`/`banc_ids()` calls from `.fanc_partners()` and `.banc_partners()`

This ensures all query resolution happens in `cf_ids`, making it the single entry point for ID resolution. Downstream functions receive only resolved numeric IDs, preparing for Phase 3 local cache support where `cf_ids` will decide whether to query locally or remotely.

## Test plan
- [ ] Verify `cf_ids(hemibrain='MBON01')` expands by default
- [ ] Verify `cf_ids(..., expand=FALSE)` sets `attr(result, 'expanded') = FALSE`
- [ ] Verify `cf_partners` errors on unexpanded queries
- [ ] Verify `cf_partners` works with raw numeric IDs
- [ ] Verify `c(cf_ids(...), cf_ids(...))` works and propagates expanded attribute