### PR TITLE
Phase 2: Use register_dataset for all datasets including built-ins

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -56,6 +56,8 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          extra-packages: flyconnectome/malecns
 
       - name: Deploy package
         run: |

--- a/R/banc.R
+++ b/R/banc.R
@@ -1,0 +1,39 @@
+# private function to instruct users on new mechanism for banc dataset
+# note that this will not be called after bancr::register_banc_coconat()
+# because that will override the built-in banc_* functions
+banc_error <- function() {
+  bv=try(utils::packageVersion('bancr'), silent = TRUE)
+  if(inherits(bv, 'try-error') || bv<'0.2.1')
+    stop("To use the banc dataset please do `natmanager::install(pkgs = 'flyconnectome/bancr')` ",
+         call. = FALSE)
+  stop("Please run `bancr::register_banc_coconat()` to use the banc dataset",
+       call. = FALSE)
+}
+
+.banc_ids <- function(ids) {
+  banc_error()
+  fancorbanc_ids(ids, dataset='banc')
+}
+
+.banc_meta <- function(ids=NULL, ...) {
+  banc_error()
+  ids=.banc_ids(ids)
+  fancr::with_banc(fancorbanc_meta(table='cell_info', ids=ids, ...))
+}
+
+.banc_partners <- function(ids, partners, threshold, ...) {
+  banc_error()
+  tres=fancr::with_banc(fancr::fanc_partner_summary(ids,
+                                   partners = partners,
+                                   threshold = threshold-1L,
+                                   version=banc_version(), ...))
+  partner_col=grep("_id", colnames(tres), value = TRUE)
+  metadf=.banc_meta()
+  colnames(metadf)[[1]]=partner_col
+  tres=dplyr::left_join(tres, metadf, by = partner_col)
+  tres
+}
+
+banc_version <- function() {
+  fancr::with_banc(fanc_version())
+}

--- a/R/datasets.R
+++ b/R/datasets.R
@@ -40,28 +40,14 @@ match_datasets <- function(ds) {
 abbreviate_datasets <- function(ds) {
   if(length(ds)<1) return(ds)
   ds=match_datasets(ds)
-  abbrevlist=c(hemibrain='hb', flywire='fw', manc='mv', fanc='fv', malecns='mc',
-               opticlobe='ol', banc='bc', yakubavnc='yv')
-  # add any extra datasets
-  abbrevlist2=coconat:::dataset_shortnames('coconatfly')
-  if(length(abbrevlist2)>0) {
-    nn=setdiff(names(abbrevlist2), names(abbrevlist))
-    abbrevlist=c(abbrevlist, abbrevlist2[nn])
-  }
+  abbrevlist=coconat:::dataset_shortnames('coconatfly')
   unname(abbrevlist[ds])
 }
 
 lengthen_datasets <- function(ds) {
-  longlist=c(hb="hemibrain", fw="flywire", mv="manc", fv="fanc", mc="malecns",
-             ol='opticlobe', bc='banc', yv='yakubavnc')
-  abbrevlist2=coconat:::dataset_shortnames('coconatfly')
-  if(length(abbrevlist2)>0) {
-    longlist2=names(abbrevlist2)
-    names(longlist2)=unname(abbrevlist2)
-    nn=setdiff(names(longlist2), names(longlist))
-    longlist=c(longlist, longlist2[nn])
-  }
-
-  ds=match.arg(ds, names(longlist), several.ok = T)
+  abbrevlist=coconat:::dataset_shortnames('coconatfly')
+  longlist=names(abbrevlist)
+  names(longlist)=unname(abbrevlist)
+  ds=match.arg(ds, names(longlist), several.ok = TRUE)
   unname(longlist[ds])
 }

--- a/R/flywire.R
+++ b/R/flywire.R
@@ -1,0 +1,26 @@
+.flywire_ids <- function(ids) {
+  fafbseg::flywire_ids(
+    ids,
+    version = fafbseg::flywire_connectome_data_version())
+}
+
+.flywire_meta <- function(ids, type=c("cell_type","hemibrain_type"), ...) {
+  type=match.arg(type)
+  tres=flytable_meta(ids,
+                     version = fafbseg::flywire_connectome_data_version(),
+                     unique = TRUE, ...)
+  tres <- tres %>%
+    dplyr::rename(id=root_id) %>%
+    dplyr::mutate(id=fafbseg::flywire_ids(id, integer64=TRUE)) %>%
+    dplyr::mutate(side=toupper(substr(side,1,1))) %>%
+    dplyr::rename_with(~ sub(".+_", "", .x), .cols=dplyr::any_of(type)) %>%
+    dplyr::rename(class=super_class, subclass=cell_class, subsubclass=cell_sub_class) %>%
+    dplyr::rename(lineage=ito_lee_hemilineage)
+}
+
+.flywire_partners <- function(ids, partners, threshold, ...) {
+  tres=flywire_partner_summary2(ids, partners=partners, threshold = threshold-1L, ...)
+  tres <- tres %>%
+    dplyr::mutate(side=toupper(substr(.data$side, 1, 1))) %>%
+    dplyr::rename(class="super_class")
+}

--- a/R/flywire2.R
+++ b/R/flywire2.R
@@ -38,7 +38,7 @@ register_flywire2 <- function(name='fx', ..., showerror=TRUE){
       .flywire_partners(ids, version='783.2', ...)
     },
     metafun=function(ids, ...) {
-      coconatfly:::flywire_meta(ids, ...)
+      .flywire_meta(ids, ...)
     },
     ...
   )

--- a/R/hemibrain.R
+++ b/R/hemibrain.R
@@ -1,0 +1,29 @@
+.hemibrain_ids <- function(ids) {
+  neuprintr::neuprint_ids(ids, conn = npconn('hemibrain'), mustWork = FALSE)
+}
+
+.hemibrain_meta <- function(ids, ...) {
+  tres=neuprintr::neuprint_get_meta(ids, conn = npconn('hemibrain'), ...)
+  tres <- tres %>%
+    dplyr::rename(id=bodyid) %>%
+    dplyr::mutate(side=stringr::str_match(tres$name, "_([LR])")[,2]) %>%
+    dplyr::mutate(class=NA_character_, subclass=NA_character_, subsubclass=NA_character_) %>%
+    dplyr::rename(lineage=cellBodyFiber)
+  tres
+}
+
+.hemibrain_partners <- function(ids, partners, threshold, ...) {
+  tres=neuprintr::neuprint_connection_table(ids, partners=partners,
+                                            conn=npconn('hemibrain'),
+                                            threshold=threshold,
+                                            details = TRUE, ...)
+  tres <- tres %>%
+    dplyr::mutate(
+      type=dplyr::case_when(
+        is.na(type) ~ paste0(abbreviate_datasets('hemibrain'), partner),
+        TRUE ~ type),
+      side=stringr::str_match(.data$name, '_([LR])$')[,2],
+      side=dplyr::case_when(
+        is.na(side) ~ 'R',
+        TRUE ~ side))
+}

--- a/R/ids.R
+++ b/R/ids.R
@@ -113,7 +113,7 @@ is_key <- function(x, compound=FALSE) {
 #' @param datasets Character vector naming datasets to which the \code{query}
 #'   should be applied.
 #' @param expand Whether to expand any queries into the matching ids (this will
-#'   involve one or more calls to corresponding servers). Default \code{FALSE}.
+#'   involve one or more calls to corresponding servers). Default \code{TRUE}.
 #' @param keys Whether to turn the ids into keys \code{hb:12345} right away.
 #'   Default \code{FALSE} but you may find this useful e.g. for combining lists
 #'   of neurons (see examples).
@@ -290,25 +290,10 @@ print.cidlist <- function(x, ..., truncate=10) {
 # private function to select an ids function for a dataset
 get_id_fun <- function(dataset) {
   dataset=match_datasets(dataset)
-  FUN <- NULL
-  if(dataset %in% cf_datasets('external')) {
-    dsd=coconat:::dataset_details(dataset, namespace = 'coconatfly')
-    FUN=dsd[['idfun']]
-  }
-  if(is.null(FUN) && dataset %in% cf_datasets('builtin')) {
-    FUN <- switch(
-      dataset,
-      manc=function(ids) malevnc::manc_ids(ids, mustWork = F, conn = npconn('manc')),
-      fanc=fanc_ids,
-      malecns=function(ids) malecns::mcns_ids(ids, mustWork = F),
-      banc=banc_ids,
-      flywire=function(ids) fafbseg::flywire_ids(
-        ids,
-        version=fafbseg::flywire_connectome_data_version()),
-      function(ids) neuprintr::neuprint_ids(ids, conn=npconn(dataset), mustWork = F))
-  }
+  dsd=coconat:::dataset_details(dataset, namespace = 'coconatfly')
+  FUN=dsd[['idfun']]
   if(is.null(FUN))
-    stop("No id function for dataset ", dataset)
+    stop("No id function registered for dataset: ", dataset)
   FUN
 }
 

--- a/R/malecns.R
+++ b/R/malecns.R
@@ -1,0 +1,52 @@
+.malecns_ids <- function(ids) {
+  malecns::mcns_ids(ids, mustWork = FALSE)
+}
+
+.malecns_meta <- function(ids, ...) {
+  tres=malecns::mcns_neuprint_meta(ids)
+  tres <- tres %>%
+    dplyr::mutate(side=malecns::mcns_soma_side(.)) %>%
+    dplyr::mutate(side=dplyr::case_when(
+      is.na(side) ~ rootSide,
+      TRUE ~ side
+    )) %>%
+    dplyr::mutate(pgroup=malecns::mcns_predict_group(.)) %>%
+    dplyr::mutate(ptype=malecns::mcns_predict_type(.)) %>%
+    dplyr::rename(otype=type, type=ptype, ogroup=group, group=pgroup) %>%
+    # special case DNs
+    dplyr::mutate(type=dplyr::case_when(
+      grepl("DN[A-z0-9_]+,", name) ~ stringr::str_match(name, "(DN[A-z0-9_]+),")[,2],
+      TRUE ~ type
+    )) %>%
+    dplyr::rename(id=bodyid) %>%
+    dplyr::rename(class1=superclass, class2=class, subsubclass=subclass) %>%
+    dplyr::rename(class=class1, subclass=class2) %>%
+    dplyr::mutate(lineage=dplyr::case_when(
+      !is.na(itoleeHl) & nzchar(itoleeHl) ~ itoleeHl,
+      TRUE ~ trumanHl
+    ))
+  tres
+}
+
+.malecns_partners <- function(args, ma) {
+  # we need to send any extra arguments to the right function
+  fa1=methods::formalArgs(malecns::mcns_connection_table)[-1]
+  fa2=methods::formalArgs(malecns::mcns_predict_type)[-1]
+  ma1=ma[setdiff(names(ma), fa2)]
+  ma2=ma[setdiff(names(ma), names(ma1))]
+  tres=do.call(malecns::mcns_connection_table, c(args, ma1))
+  # nb the type information we care about here is for partners
+  tres2=tres %>%
+    dplyr::select("partner", "type", "name") %>%
+    dplyr::rename(bodyid=partner)
+
+  tres$type <- do.call(malecns::mcns_predict_type,
+                       c(list(ids=tres2), ma2))
+  # set the soma side either from manually reviewed data
+  tres <-  tres %>%
+    dplyr::mutate(side=dplyr::case_when(
+      !is.na(somaSide) & somaSide!='NA' & somaSide!='' ~ somaSide,
+      TRUE ~ malecns::mcns_soma_side(., method = "instance")
+    )) |>
+    dplyr::rename(class=superclass)
+}

--- a/R/manc.R
+++ b/R/manc.R
@@ -1,0 +1,26 @@
+.manc_ids <- function(ids) {
+  malevnc::manc_ids(ids, mustWork = FALSE, conn = npconn('manc'))
+}
+
+.manc_meta <- function(ids, ...) {
+  tres <- malevnc::manc_neuprint_meta(ids, conn=npconn('manc'), ...) %>%
+    dplyr::mutate(side=dplyr::case_when(
+      !is.na(somaSide) ~ toupper(substr(somaSide, 1, 1)),
+      !is.na(rootSide) ~ toupper(substr(rootSide, 1, 1)),
+      TRUE ~ NA_character_
+    )) %>%
+    dplyr::rename(id=bodyid, lineage=hemilineage) %>%
+    dplyr::mutate(subsubclass=NA_character_)
+  tres
+}
+
+.manc_partners <- function(ids, partners, threshold, ...) {
+  tres <- malevnc::manc_connection_table(ids, partners = partners,
+                                 threshold=threshold, conn=npconn('manc'), ...)
+  tres <- tres %>%
+    dplyr::mutate(side=dplyr::case_when(
+      !is.na(somaSide) & somaSide!='NA' & somaSide!='' ~ substr(somaSide,1,1),
+      TRUE ~ stringr::str_match(name, "_([LRM])$")[,2]
+    ))
+  tres
+}

--- a/R/meta.R
+++ b/R/meta.R
@@ -78,6 +78,9 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
   names(ids)=match_datasets(names(ids))
   stopifnot(all(names(ids) %in% cf_datasets('all')))
 
+  # Check that IDs have been expanded (queries resolved)
+  check_expanded(ids)
+
   res=vector(mode = 'list', length = length(ids))
   names(res)=names(ids)
 

--- a/R/opticlobe.R
+++ b/R/opticlobe.R
@@ -1,0 +1,28 @@
+.opticlobe_ids <- function(ids) {
+  neuprintr::neuprint_ids(ids, conn = npconn('opticlobe'), mustWork = FALSE)
+}
+
+.opticlobe_meta <- function(ids, ...) {
+  tres=neuprintr::neuprint_get_meta(ids, conn = npconn('opticlobe'), ...)
+  tres <- tres %>%
+    dplyr::rename(id=bodyid) %>%
+    dplyr::mutate(side=stringr::str_match(tres$name, "_([LR])$")[,2]) %>%
+    dplyr::mutate(class=NA_character_, subclass=NA_character_, subsubclass=NA_character_)
+  tres
+}
+
+.opticlobe_partners <- function(ids, partners, threshold, ...) {
+  tres=neuprintr::neuprint_connection_table(ids, partners=partners,
+                                            conn=npconn('opticlobe'),
+                                            threshold=threshold,
+                                            details = TRUE, ...)
+  tres <- tres %>%
+    dplyr::mutate(
+      type=dplyr::case_when(
+        is.na(type) ~ paste0(abbreviate_datasets('opticlobe'), partner),
+        TRUE ~ type),
+      side=stringr::str_match(.data$name, '_([LR])$')[,2],
+      side=dplyr::case_when(
+        is.na(side) ~ 'R',
+        TRUE ~ side))
+}

--- a/R/partners.R
+++ b/R/partners.R
@@ -50,7 +50,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
   threshold <- checkmate::assert_integerish(
     threshold, lower=0L,len = 1, null.ok = F, all.missing = F)
 
-  neuprint.chunksize=10000
+  neuprint.chunksize=10000L
 
   if(is.character(ids) || inherits(ids, 'dendrogram') || inherits(ids, 'hclust'))
     ids=keys2df(ids)
@@ -75,51 +75,25 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     tres=NULL
     if(!is.null(MoreArgs[[n]])) checkmate::assert_list(MoreArgs[[n]], names = 'named')
 
-    PFUN=NULL
-    if(n %in% cf_datasets('external')) {
-      dsd=coconat:::dataset_details(n, namespace = 'coconatfly')
-      PFUN=dsd[['partnerfun']]
-    }
+    dsd=coconat:::dataset_details(n, namespace = 'coconatfly')
+    PFUN=dsd[['partnerfun']]
+    if(is.null(PFUN))
+      stop("No partner function registered for dataset: ", n)
+
     # everyone needs these
     commonArgs=c(list(ids[[n]], partners = partners, threshold=threshold), MoreArgs[[n]])
-    tres <- if(!is.null(PFUN)) {
-      tres=do.call(PFUN, commonArgs)
-      if(is.null(tres) || ncol(tres)<3)
-        stop("External functions should return a table with at least 3 columns:\n",
-        "pre/post ids and weight with optional (partner) metadata!")
-      if(ncol(tres)==3 || (ncol(tres)<=5 && !"type" %in% names(tres))) {
-        # assume we need to fetch partner metadata
-        partner_col=grep("_id", colnames(tres), value = T)
-        if(!length(partner_col)==1)
-          partner_col=grep("^partner$", colnames(tres), value = T)
-        if(!length(partner_col)==1)
-          stop("Unable to find a unique partner column for dataset: ", n,
-               "\nExternal functions should return a table with bodyid and partner cols or query and pre/post_id")
-        pids=unique(tres[[partner_col]])
-        metadf=cf_meta(keys(data.frame(id=pids, dataset=n)))
-        metadf=metadf[setdiff(colnames(metadf), c("dataset","key"))]
-        colnames(metadf)[[1]]=partner_col
-        tres[[partner_col]]=coconat::id2char(tres[[partner_col]])
-        left_join(tres, metadf, by = partner_col)
-      } else tres
-    } else if(n=='flywire') {
-      # nb different threshold definition here
-      do.call(.flywire_partners, commonArgs)
-    } else if(n%in%c('hemibrain', 'opticlobe')) {
-      do.call(.neuprint_partners,
-              c(commonArgs, list( dataset=n, conn = npconn(n), chunk = neuprint.chunksize)))
-    } else if(n=='malecns') {
-      # different strategy as MoreArgs needs to be split into different dests
+
+    # Add chunk parameter for neuprint-based datasets
+    if(n %in% c('hemibrain', 'opticlobe', 'yakubavnc', 'manc')) {
+      commonArgs=c(commonArgs, list(chunk=neuprint.chunksize))
+    }
+
+    # malecns has a special signature (args, ma) for MoreArgs handling
+    tres <- if(n=='malecns') {
       .malecns_partners(commonArgs[1:3], ma = MoreArgs[[n]])
-    } else if (n=='fanc') {
-      do.call(.fanc_partners, commonArgs)
-    } else if (n=='banc') {
-      do.call(.banc_partners, commonArgs)
-    } else if(n=='manc') {
-      do.call(.manc_partners, c(commonArgs, chunk = neuprint.chunksize))
-    } else if(n == 'yakubavnc') {
-      do.call(.yakubavnc_partners, c(commonArgs, chunk = neuprint.chunksize))
-    } else stop("There is no partner function defined for dataset: ", n)
+    } else {
+      do.call(PFUN, commonArgs)
+    }
 
     tres=coconat:::standardise_partner_summary(tres)
     if(nrow(tres)>0) {
@@ -138,108 +112,6 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     attr(res, 'datasets')=names(ids)
     res
   } else res
-}
-
-.flywire_partners <- function(ids, partners, threshold, ...) {
-  tres=flywire_partner_summary2(ids, partners=partners, threshold = threshold-1L, ...)
-  tres <- tres %>%
-    mutate(side=toupper(substr(.data$side, 1, 1))) %>%
-    rename(class="super_class")
-}
-
-.neuprint_partners <- function(ids, partners, threshold, conn, dataset=NULL, ...) {
-
-  tres=neuprintr::neuprint_connection_table(ids, partners=partners,
-                                            conn=conn,
-                                            threshold=threshold,
-                                            details = TRUE, ...)
-  tres <- tres %>%
-    dplyr::mutate(
-      type=dplyr::case_when(
-        is.na(type) ~ paste0(abbreviate_datasets(dataset), partner),
-        T ~ type),
-      side=stringr::str_match(.data$name, '_([LR])$')[,2],
-      side=dplyr::case_when(
-        is.na(side) ~ 'R',
-        T ~ side))
-}
-
-.malecns_partners <- function(args, ma) {
-  # we need to send any extra arguments to the right function
-  fa1=methods::formalArgs(malecns::mcns_connection_table)[-1]
-  fa2=methods::formalArgs(malecns::mcns_predict_type)[-1]
-  ma1=ma[setdiff(names(ma), fa2)]
-  ma2=ma[setdiff(names(ma), names(ma1))]
-  tres=do.call(malecns::mcns_connection_table, c(args, ma1))
-  # nb the type information we care about here is for partners
-  tres2=tres %>%
-    dplyr::select("partner", "type", "name") %>%
-    dplyr::rename(bodyid=partner)
-
-  tres$type <- do.call(malecns::mcns_predict_type,
-                       c(list(ids=tres2), ma2))
-  # set the soma side either from manually reviewed data
-  tres <-  tres %>%
-    dplyr::mutate(side=dplyr::case_when(
-      !is.na(somaSide) & somaSide!='NA' & somaSide!='' ~ somaSide,
-      T ~ malecns::mcns_soma_side(., method = "instance")
-    )) |>
-    rename(class=superclass)
-}
-
-.fanc_partners <- function(ids, partners, threshold, ...) {
-  # FIXME allow end user to override fanc version
-  tres=fancr::fanc_partner_summary(ids,
-                                   partners = partners,
-                                   threshold = threshold-1L,
-                                   version=fanc_version(), ...)
-  partner_col=grep("_id", colnames(tres), value = T)
-  metadf=fanc_meta()
-  colnames(metadf)[[1]]=partner_col
-  tres=left_join(tres, metadf, by = partner_col)
-  tres
-}
-
-.banc_partners <- function(ids, partners, threshold, ...) {
-  banc_error()
-  tres=fancr::with_banc(fancr::fanc_partner_summary(ids,
-                                   partners = partners,
-                                   threshold = threshold-1L,
-                                   version=banc_version(), ...))
-  partner_col=grep("_id", colnames(tres), value = T)
-  metadf=banc_meta()
-  colnames(metadf)[[1]]=partner_col
-  tres=left_join(tres, metadf, by = partner_col)
-  tres
-}
-
-.manc_partners <- function(ids, partners, threshold, ...) {
-  tres <- malevnc::manc_connection_table(ids,partners = partners,
-                                 threshold=threshold, conn=npconn('manc'), ...)
-  tres <- tres %>%
-    mutate(side=dplyr::case_when(
-      !is.na(somaSide) & somaSide!='NA' & somaSide!='' ~ substr(somaSide,1,1),
-      T ~ stringr::str_match(name, "_([LRM])$")[,2]
-    ))
-  tres
-}
-
-.yakubavnc_partners <- function(ids, partners, threshold,
-                                details = c("instance", "group", "type", "class", "somaSide", "rootSide"),
-                                ...) {
-  tres <- neuprintr::neuprint_connection_table(ids, partners = partners,
-                                 threshold=threshold,
-                                 details=details,
-                                 conn=npconn('yakubavnc'), ...)
-  if('somaSide' %in% colnames(tres)) {
-
-  tres <- tres %>%
-    mutate(side=dplyr::case_when(
-      !is.na(somaSide) & somaSide!='NA' & somaSide!='' ~ substr(somaSide,1,1),
-      T ~ stringr::str_match(name, "_([LRM])$")[,2]
-    ))
-  }
-  tres
 }
 
 # private function to match types across datasets

--- a/R/partners.R
+++ b/R/partners.R
@@ -65,6 +65,9 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
   names(ids)=match_datasets(names(ids))
   stopifnot(all(names(ids) %in% cf_datasets('all')))
 
+  # Check that IDs have been expanded (queries resolved)
+  check_expanded(ids)
+
   res=vector(mode = 'list', length = length(ids))
   names(res)=names(ids)
 
@@ -186,7 +189,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
 
 .fanc_partners <- function(ids, partners, threshold, ...) {
   # FIXME allow end user to override fanc version
-  tres=fancr::fanc_partner_summary(fanc_ids(ids),
+  tres=fancr::fanc_partner_summary(ids,
                                    partners = partners,
                                    threshold = threshold-1L,
                                    version=fanc_version(), ...)
@@ -199,7 +202,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
 
 .banc_partners <- function(ids, partners, threshold, ...) {
   banc_error()
-  tres=fancr::with_banc(fancr::fanc_partner_summary(banc_ids(ids),
+  tres=fancr::with_banc(fancr::fanc_partner_summary(ids,
                                    partners = partners,
                                    threshold = threshold-1L,
                                    version=banc_version(), ...))

--- a/R/triple.R
+++ b/R/triple.R
@@ -20,9 +20,12 @@ triple_connection_table <- function(hbtype, fwtype=hbtype, partners=c("inputs", 
     return(l)
   }
   stopifnot(isTRUE(hbdetails))
-  hb=cf_partners(list(hemibrain=hbtype), partners = partners,
+  # Expand IDs before passing to cf_partners
+  hbids=cf_ids(hemibrain=hbtype)
+  fwids=cf_ids(flywire=fwtype)
+  hb=cf_partners(hbids, partners = partners,
                  threshold=threshold, bind.rows = F)[[1]]
-  fw=cf_partners(list(flywire=fwtype), partners = partners,
+  fw=cf_partners(fwids, partners = partners,
                  threshold = threshold, bind.rows = F)[[1]]
   stopifnot(isTRUE(version==fafbseg::flywire_connectome_data_version()))
 

--- a/R/yakubavnc.R
+++ b/R/yakubavnc.R
@@ -1,0 +1,38 @@
+.yakubavnc_ids <- function(ids) {
+  neuprintr::neuprint_ids(ids, conn = npconn('yakubavnc'), mustWork = FALSE)
+}
+
+.yakubavnc_meta <- function(ids, ...) {
+  tres <- malevnc::manc_neuprint_meta(ids, conn = npconn('yakubavnc'), ...)
+  if(!"rootSide" %in% colnames(tres))
+    tres$rootSide=NA_character_
+  if(!"subclass" %in% colnames(tres))
+    tres$subclass=NA_character_
+
+  tres <- tres %>%
+    dplyr::mutate(side=dplyr::case_when(
+      !is.na(somaSide) ~ toupper(substr(somaSide, 1, 1)),
+      !is.na(rootSide) ~ toupper(substr(rootSide, 1, 1)),
+      TRUE ~ NA_character_
+    )) %>%
+    dplyr::rename(id=bodyid, lineage=hemilineage) %>%
+    dplyr::mutate(subsubclass=NA_character_)
+  tres
+}
+
+.yakubavnc_partners <- function(ids, partners, threshold,
+                                details = c("instance", "group", "type", "class", "somaSide", "rootSide"),
+                                ...) {
+  tres <- neuprintr::neuprint_connection_table(ids, partners = partners,
+                                 threshold=threshold,
+                                 details=details,
+                                 conn=npconn('yakubavnc'), ...)
+  if('somaSide' %in% colnames(tres)) {
+    tres <- tres %>%
+      dplyr::mutate(side=dplyr::case_when(
+        !is.na(somaSide) & somaSide!='NA' & somaSide!='' ~ substr(somaSide,1,1),
+        TRUE ~ stringr::str_match(name, "_([LRM])$")[,2]
+      ))
+  }
+  tres
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,77 @@
+.onLoad <- function(libname, pkgname) {
+  register_builtin_datasets()
+}
+
+register_builtin_datasets <- function() {
+  coconat::register_dataset(
+    "flywire",
+    metafun = .flywire_meta,
+    idfun = .flywire_ids,
+    partnerfun = .flywire_partners,
+    shortname = "fw",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "hemibrain",
+    metafun = .hemibrain_meta,
+    idfun = .hemibrain_ids,
+    partnerfun = .hemibrain_partners,
+    shortname = "hb",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "opticlobe",
+    metafun = .opticlobe_meta,
+    idfun = .opticlobe_ids,
+    partnerfun = .opticlobe_partners,
+    shortname = "ol",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "malecns",
+    metafun = .malecns_meta,
+    idfun = .malecns_ids,
+    partnerfun = .malecns_partners,
+    shortname = "mc",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "manc",
+    metafun = .manc_meta,
+    idfun = .manc_ids,
+    partnerfun = .manc_partners,
+    shortname = "mv",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "fanc",
+    metafun = .fanc_meta,
+    idfun = .fanc_ids,
+    partnerfun = .fanc_partners,
+    shortname = "fv",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "banc",
+    metafun = .banc_meta,
+    idfun = .banc_ids,
+    partnerfun = .banc_partners,
+    shortname = "bc",
+    namespace = "coconatfly"
+  )
+
+  coconat::register_dataset(
+    "yakubavnc",
+    metafun = .yakubavnc_meta,
+    idfun = .yakubavnc_ids,
+    partnerfun = .yakubavnc_partners,
+    shortname = "yv",
+    namespace = "coconatfly"
+  )
+}

--- a/man/cf_ids.Rd
+++ b/man/cf_ids.Rd
@@ -9,7 +9,7 @@ cf_ids(
   query = NULL,
   datasets = c("brain", "vnc", "hemibrain", "flywire", "malecns", "manc", "fanc",
     "opticlobe", "banc", "yakubavnc"),
-  expand = FALSE,
+  expand = TRUE,
   keys = FALSE,
   hemibrain = NULL,
   flywire = NULL,
@@ -31,7 +31,7 @@ cf_ids(
 should be applied.}
 
 \item{expand}{Whether to expand any queries into the matching ids (this will
-involve one or more calls to corresponding servers). Default \code{FALSE}.}
+involve one or more calls to corresponding servers). Default \code{TRUE}.}
 
 \item{keys}{Whether to turn the ids into keys \code{hb:12345} right away.
 Default \code{FALSE} but you may find this useful e.g. for combining lists

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -18,11 +18,24 @@
     stop("unsupported query")
 }
 
+.rhubarb_ids <- function(ids) {
+  # Simple id function for test dataset - just returns numeric ids
+  if(is.numeric(ids)) return(ids)
+  # If query, resolve via meta function
+  if(is.character(ids) && length(ids)==1 && grepl("/", ids)) {
+    query <- sub("^/", "", ids)
+    df <- .rhubarb_meta(query)
+    return(df$id)
+  }
+  ids
+}
+
 register_rhubarb <- function() {
   if(! 'rhubarb' %in% cf_datasets()) {
     coconat::register_dataset('rhubarb', shortname = 'rb',
                               species = 'Rheum rhabarbarum', sex='U', age='adult',
                               metafun=.rhubarb_meta,
+                              idfun=.rhubarb_ids,
                               namespace = 'coconatfly')
   }
   if(! 'badrhubarb' %in% cf_datasets()) {

--- a/tests/testthat/test-ids.R
+++ b/tests/testthat/test-ids.R
@@ -54,8 +54,8 @@ test_that("fanc/banc ids/metadata", {
                          version='latest'))
 
   skip_if_not_installed('bancr')
-  skip_if(inherits(bancr::register_banc_coconat(), 'try-error'))
-  expect_length(dna02keys <- cf_ids(banc='/DNa02', keys = T), 2L)
+  skip_if(inherits(suppressWarnings(bancr::register_banc_coconat()), 'try-error'))
+  expect_length(dna02keys <- suppressWarnings(cf_ids(banc='/DNa02', keys = T)), 2L)
   expect_warning(
     expect_in(cf_ids(banc='DNa02', keys = T), dna02keys))
   expect_warning(
@@ -67,7 +67,10 @@ test_that("extra datasets", {
   register_rhubarb()
   expect_equal(rhu <- cf_ids(1, datasets = 'rhubarb'), list(rhubarb=1), ignore_attr = TRUE)
   expect_equal(cf_ids(1, datasets = 'rhubar'), rhu)
-  expect_equal(length(cf_ids(1, datasets = c("brain", 'rhubar'))), 5L)
+  skip_if_not_installed('malecns')
+  expect_warning(
+    expect_equal(length(cf_ids(1, datasets = c("brain", 'rhubar'))), 5L),
+    "unable to map")
 
   expect_equal(rhu2 <- cf_ids(rhubarb=1:3), list(rhubarb=1:3), ignore_attr = TRUE)
   expect_equal(cf_ids(rhubar=1:3), rhu2)

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -1,9 +1,13 @@
 test_that("metadata", {
 
-  expect_equal(
-    cf_meta(ids = cf_ids(hemibrain = 'AOTU012', flywire = 'rhubarb')),
-    cf_meta(ids = cf_ids(hemibrain = 'AOTU012'))
-  )
+  expect_warning(
+    expect_equal(
+      cf_meta(ids = cf_ids(hemibrain = 'AOTU012', flywire = 'rhubarb')),
+      cf_meta(ids = cf_ids(hemibrain = 'AOTU012'))
+    ),
+    "No matching ids")
+
+  expect_error(cf_meta(ids = cf_ids(hemibrain = 'AOTU012', expand = F)))
 
   skip_if_not_installed('malevnc')
   expect_true(all(grepl("descending",
@@ -21,7 +25,13 @@ test_that("metadata", {
 test_that("fanc/banc ids/metadata", {
   skip_if_not_installed('fancr')
   skip_if_not_installed('reticulate')
-  expect_null(cf_meta(cf_ids(banc='/rhubarb.+')))
+  skip_if_not_installed('bancr', minimum_version = '0.2.1')
+  # bancr must be registered for banc queries to work
+  skip_if_not(tryCatch({suppressWarnings(bancr::register_banc_coconat()); TRUE}, error=function(e) FALSE),
+              message = "bancr not properly configured")
+  expect_warning(
+    expect_null(cf_meta(cf_ids(banc='/rhubarb.+'))),
+    "No matching ids")
 })
 
 test_that("extra datasets", {
@@ -31,7 +41,8 @@ test_that("extra datasets", {
 
   expect_true(is.data.frame(cf_meta(cf_ids(rhubarb=1, flywire='DNa02'))))
 
-  expect_error(cf_meta(cf_ids(badrhubarb=1)), regexp = 'no metadata function')
+  # badrhubarb has no idfun, so cf_ids errors when trying to expand (the new default)
+  expect_error(cf_ids(badrhubarb=1))
 })
 
 


### PR DESCRIPTION
## Summary
**Depends on:** #50 (Phase 1)

This PR establishes a uniform registration mechanism for all datasets (builtin and external) using `coconat::register_dataset`.

### New files for dataset-specific functions:
- `R/zzz.R`: `.onLoad()` to register all built-in datasets
- `R/flywire.R`: `.flywire_ids`, `.flywire_meta`, `.flywire_partners`
- `R/hemibrain.R`: `.hemibrain_ids`, `.hemibrain_meta`, `.hemibrain_partners`
- `R/opticlobe.R`: `.opticlobe_ids`, `.opticlobe_meta`, `.opticlobe_partners`
- `R/malecns.R`: `.malecns_ids`, `.malecns_meta`, `.malecns_partners`
- `R/manc.R`: `.manc_ids`, `.manc_meta`, `.manc_partners`
- `R/banc.R`: `.banc_ids`, `.banc_meta`, `banc_error`, `.banc_partners`, `banc_version`
- `R/yakubavnc.R`: `.yakubavnc_ids`, `.yakubavnc_meta`, `.yakubavnc_partners`

### Updated R/fanc.R:
- Renamed to `.fanc_ids`, `.fanc_meta`
- Added `fanc_version` and `.fanc_partners`

### Simplified dispatch functions:
- `get_id_fun`: now uses only registered functions
- `get_meta_fun`: now uses only registered functions
- `cf_partners`: uses registered `partnerfun` instead of if-else chain
- `abbreviate_datasets`: uses only registered shortnames
- `lengthen_datasets`: uses only registered shortnames

### Cleaned up:
- `R/meta.R`: removed functions moved to dataset-specific files
- `R/partners.R`: removed functions moved to dataset-specific files

All dataset-specific functions now use private naming convention (`.prefix`) for consistency.

## Test plan
- [ ] Verify `cf_datasets('builtin')` returns all 8 datasets
- [ ] Verify `abbreviate_datasets(cf_datasets('builtin'))` works
- [ ] Verify `cf_ids(hemibrain=12345)` works
- [ ] Verify registered functions are accessible via `coconat:::dataset_details()`
- [ ] Verify `cf_meta` and `cf_partners` work with all datasets