### PR TITLE
Harmonise metadata columns across datasets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,10 @@ Imports:
     withr,
     utils,
     tibble
-Suggests: 
+Suggests:
     malevnc (> 0.3.1),
+    malecns (>= 0.3.3),
+    snakecase,
     fancr (>= 0.5.0),
     testthat (>= 3.0.0),
     ComplexHeatmap,
@@ -47,10 +49,9 @@ Suggests:
     dendroextras,
     tidyr,
     reticulate
-Enhances:
-    malecns (>= 0.3.3)
-Remotes: 
+Remotes:
     flyconnectome/malevnc,
+    flyconnectome/malecns,
     flyconnectome/fancr,
     natverse/fafbseg,
     natverse/nat,

--- a/R/coconatfly-package.R
+++ b/R/coconatfly-package.R
@@ -8,6 +8,9 @@
 #'   \code{\link{cf_meta}}, \code{\link{cf_partners}}, and
 #'   \code{\link{cf_partner_summary}}. Default: \code{FALSE}.
 #'   Set with \code{options(coconatfly.use_superclass = TRUE)}.}
+#'   \item{\code{coconatfly.harmonise_class}}{Logical. If \code{TRUE}, harmonise
+#'   class values to malecns style across all datasets. Default: \code{FALSE}.
+#'   Set with \code{options(coconatfly.harmonise_class = TRUE)}.}
 #' }
 "_PACKAGE"
 

--- a/R/meta.R
+++ b/R/meta.R
@@ -168,6 +168,15 @@ dataset_tissue <- function(ds) {
   )
 }
 
+#' Get sex for a dataset from registration
+#' @noRd
+dataset_sex <- function(ds) {
+
+  dsd <- coconat:::dataset_details(ds, namespace = 'coconatfly')
+  sex <- dsd[['sex']]
+  if (is.null(sex)) NA_character_ else sex
+}
+
 #' Normalise side values to L/R/M/NA
 #'
 #' Accepts various input formats (left, right, midline, L, R, M, etc.)
@@ -256,7 +265,7 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
     if(inherits(tres, 'try-error') || is.null(tres) || !isTRUE(nrow(tres)>0))
       next
     tres$id=flywire_ids(tres$id, integer64=integer64, na_ok=TRUE)
-    cols_we_want=c("id", "class", "subclass", "type", 'side', 'tissue', 'group', "instance")
+    cols_we_want=c("id", "class", "subclass", "type", 'side', 'sex', 'tissue', 'group', "instance")
     missing_cols=setdiff(cols_we_want, colnames(tres))
     if('class' %in% missing_cols)
       tres$class=NA_character_
@@ -268,6 +277,8 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
       tres$group=bit64::as.integer64(NA)
     if('tissue' %in% missing_cols)
       tres$tissue=dataset_tissue(n)
+    if('sex' %in% missing_cols)
+      tres$sex=dataset_sex(n)
     if('side' %in% missing_cols)
       tres$side=NA_character_
     if('instance' %in% missing_cols) {

--- a/R/meta.R
+++ b/R/meta.R
@@ -138,7 +138,7 @@ harmonise_top_class_values <- function(class, dataset, unknown_as_na = FALSE) {
   mapped
 }
 
-#' Get tissue domain prefix for a dataset
+#' Get tissue domain prefix for a dataset (used for class harmonisation)
 #' @noRd
 dataset_domain <- function(ds) {
   switch(ds,
@@ -150,6 +150,41 @@ dataset_domain <- function(ds) {
     opticlobe = "ol",
     NA_character_
   )
+}
+
+#' Get tissue type for a dataset
+#' @noRd
+dataset_tissue <- function(ds) {
+  switch(ds,
+    flywire = "brain",
+    hemibrain = "brain",
+    opticlobe = "brain",
+    manc = "vnc",
+    fanc = "vnc",
+    yakubavnc = "vnc",
+    malecns = "cns",
+    banc = "cns",
+    NA_character_
+  )
+}
+
+#' Normalise side values to L/R/M/NA
+#'
+#' Accepts various input formats (left, right, midline, L, R, M, etc.)
+#' and normalises to single uppercase letters or NA.
+#' @param x Character vector of side values
+#' @return Character vector with values L, R, M, or NA only
+#' @noRd
+normalise_side <- function(x) {
+  x <- as.character(x)
+  x <- tolower(trimws(x))
+
+  result <- rep(NA_character_, length(x))
+  result[grepl("^l(eft)?$", x)] <- "L"
+  result[grepl("^r(ight)?$", x)] <- "R"
+  result[grepl("^m(idline)?$|^c(enter|entre)?$", x)] <- "M"
+
+  result
 }
 
 #' Fetch metadata for neurons from connectome datasets
@@ -221,12 +256,20 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
     if(inherits(tres, 'try-error') || is.null(tres) || !isTRUE(nrow(tres)>0))
       next
     tres$id=flywire_ids(tres$id, integer64=integer64, na_ok=TRUE)
-    cols_we_want=c("id", "class", "subclass", "type", 'side', 'group', "instance")
+    cols_we_want=c("id", "class", "subclass", "type", 'side', 'tissue', 'group', "instance")
     missing_cols=setdiff(cols_we_want, colnames(tres))
     if('class' %in% missing_cols)
       tres$class=NA_character_
+    if('subclass' %in% missing_cols)
+      tres$subclass=NA_character_
+    if('type' %in% missing_cols)
+      tres$type=NA_character_
     if('group' %in% missing_cols)
       tres$group=bit64::as.integer64(NA)
+    if('tissue' %in% missing_cols)
+      tres$tissue=dataset_tissue(n)
+    if('side' %in% missing_cols)
+      tres$side=NA_character_
     if('instance' %in% missing_cols) {
       tres <-if('name' %in% colnames(tres))
         tres %>% rename(instance=name)
@@ -248,6 +291,8 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
     if(length(missing_cols)>0)
       stop("We are missing columns: ", paste(missing_cols, collapse = ','))
     tres$class=harmonise_top_class_values(tres$class, n)
+    if("side" %in% colnames(tres))
+      tres$side=normalise_side(tres$side)
     tres$dataset=n
     tres$key=keys(tres)
     res[[n]]=tres

--- a/R/meta.R
+++ b/R/meta.R
@@ -198,8 +198,21 @@ normalise_side <- function(x) {
 
 #' Fetch metadata for neurons from connectome datasets
 #'
-#' @details \code{MoreArgs} is structured as a list with a top layer naming datasets
-#'   (using the same long names as \code{\link{cf_datasets}}. The second (lower)
+#' @details The returned data frame includes these standard columns:
+#' \itemize{
+#'   \item \code{id}, \code{key}: neuron identifiers (key is unique across datasets)
+#'   \item \code{class}, \code{subclass}, \code{type}: cell class hierarchy
+#'     (harmonised to malecns style across datasets)
+#'   \item \code{instance}: summarises properties of individual neurons
+#'   \item \code{side}: normalised to L/R/M (left/right/midline) or NA
+#'   \item \code{sex}: M or F, from dataset registration
+#'   \item \code{tissue}: brain, vnc, or cns depending on dataset
+#'   \item \code{group}: numeric, defines related neurons within dataset
+#'   \item \code{dataset}: source dataset name
+#' }
+#'
+#' \code{MoreArgs} is structured as a list with a top layer naming datasets
+#'   (using the same long names as \code{\link{cf_datasets}}). The second (lower)
 #'   layer names the arguments that will be passed to dataset-specific functions.
 #'
 #' @param ids A list of ids named by the relevant datasets (see examples) or any

--- a/R/meta.R
+++ b/R/meta.R
@@ -66,6 +66,92 @@ rename_to_superclass <- function(df) {
   df
 }
 
+#' Harmonise top-level class values across datasets
+#'
+#' Uses regex-based rules to normalise class labels to malecns-style values.
+#' Rules are applied in order; first match wins. For base classes (sensory,
+#' motor, etc.), a domain prefix (cb/vnc/ol) is added based on dataset.
+#'
+#' @param class Character vector of class values
+#' @param dataset Character vector of dataset names (recycled if length 1)
+#' @param unknown_as_na If TRUE, return NA for unmatched values
+#' @return Character vector of normalised class values
+#' @noRd
+harmonise_top_class_values <- function(class, dataset, unknown_as_na = FALSE) {
+  if (length(class) == 0) return(class)
+  class <- as.character(class)
+  dataset <- as.character(dataset)
+  if (length(dataset) == 1L) dataset <- rep(dataset, length(class))
+  stopifnot(length(dataset) == length(class))
+
+  # Normalise to lowercase with underscores
+  toks <- tolower(trimws(class))
+  toks <- gsub("[[:space:]-]+", "_", toks)
+  toks <- gsub("_+", "_", toks)  # collapse multiple underscores
+  toks <- gsub("^_|_$", "", toks)  # remove leading/trailing underscores
+
+  # Helper to extract direction (ascending/descending) from token
+  get_direction <- function(tok) {
+    if (grepl("ascending", tok)) "ascending"
+    else if (grepl("descending", tok)) "descending"
+    else NA_character_
+  }
+
+  mapped <- class
+  for (i in seq_along(toks)) {
+    ds <- dataset[i]
+    # Skip datasets already in target schema or not yet supported
+    if (ds %in% c("malecns", "banc")) next
+
+    tok <- toks[i]
+    dir <- get_direction(tok)
+
+    # Apply rules in order (first match wins)
+    result <- if (grepl("sensory|sensory_tbd", tok) && !is.na(dir)) {
+      paste0("sensory_", dir)
+    } else if (grepl("efferent", tok) && !is.na(dir)) {
+      paste0("efferent_", dir)
+    } else if (grepl("^(ascending|descending)(_neuron)?$", tok) && !is.na(dir)) {
+      paste0(dir, "_neuron")
+    } else if (grepl("centrifugal", tok)) {
+      "visual_centrifugal"
+    } else if (grepl("visual.*projection|^projection$", tok)) {
+      "visual_projection"
+    } else if (grepl("endocrine", tok)) {
+      "endocrine"
+    } else if (grepl("^optic$", tok)) {
+      "ol_intrinsic"
+    } else if (grepl("sensory|sensory_tbd", tok)) {
+      paste0(dataset_domain(ds), "_sensory")
+    } else if (grepl("efferent", tok)) {
+      paste0(dataset_domain(ds), "_efferent")
+    } else if (grepl("motor", tok)) {
+      paste0(dataset_domain(ds), "_motor")
+    } else if (grepl("intrinsic|central", tok)) {
+      paste0(dataset_domain(ds), "_intrinsic")
+    } else {
+      if (unknown_as_na) NA_character_ else class[i]
+    }
+
+    mapped[i] <- result
+  }
+  mapped
+}
+
+#' Get tissue domain prefix for a dataset
+#' @noRd
+dataset_domain <- function(ds) {
+  switch(ds,
+    manc = "vnc",
+    fanc = "vnc",
+    yakubavnc = "vnc",
+    flywire = "cb",
+    hemibrain = "cb",
+    opticlobe = "ol",
+    NA_character_
+  )
+}
+
 #' Fetch metadata for neurons from connectome datasets
 #'
 #' @details \code{MoreArgs} is structured as a list with a top layer naming datasets
@@ -161,6 +247,7 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
     missing_cols=setdiff(cols_we_want, colnames(tres))
     if(length(missing_cols)>0)
       stop("We are missing columns: ", paste(missing_cols, collapse = ','))
+    tres$class=harmonise_top_class_values(tres$class, n)
     tres$dataset=n
     tres$key=keys(tres)
     res[[n]]=tres

--- a/R/meta.R
+++ b/R/meta.R
@@ -226,6 +226,9 @@ normalise_side <- function(x) {
 #' @param use_superclass If \code{TRUE}, rename class/subclass/subsubclass
 #'   columns to superclass/class/subclass. Can also be set via the
 #'   \code{coconatfly.use_superclass} option.
+#' @param harmonise_class If \code{TRUE}, harmonise class values to malecns
+#'   style across all datasets. Can also be set via the
+#'   \code{coconatfly.harmonise_class} option.
 #' @param bind.rows Whether to bind data.frames for each dataset together,
 #'   keeping only the common columns (default \code{TRUE} for convenience but
 #'   note that some columns will be dropped by unless \code{keep.all=TRUE}).
@@ -246,6 +249,7 @@ normalise_side <- function(x) {
 #' }
 cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
                     use_superclass=getOption("coconatfly.use_superclass", FALSE),
+                    harmonise_class=getOption("coconatfly.harmonise_class", FALSE),
                     MoreArgs=list(flywire=list(type=c("cell_type","hemibrain_type")))) {
   if(is.character(ids) || inherits(ids, 'dendrogram') || inherits(ids, 'hclust'))
     ids=keys2df(ids)
@@ -253,7 +257,7 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
     stopifnot(bind.rows)
     ss=split(ids$id, ids$dataset)
     res=cf_meta(ss, integer64 = integer64, MoreArgs = MoreArgs, keep.all=keep.all,
-                use_superclass=use_superclass)
+                use_superclass=use_superclass, harmonise_class=harmonise_class)
     res=res[match(keys(ids), res$key),,drop=F]
     return(res)
   }
@@ -314,7 +318,8 @@ cf_meta <- function(ids, bind.rows=TRUE, integer64=FALSE, keep.all=FALSE,
     missing_cols=setdiff(cols_we_want, colnames(tres))
     if(length(missing_cols)>0)
       stop("We are missing columns: ", paste(missing_cols, collapse = ','))
-    tres$class=harmonise_top_class_values(tres$class, n)
+    if(isTRUE(harmonise_class))
+      tres$class=harmonise_top_class_values(tres$class, n)
     if("side" %in% colnames(tres))
       tres$side=normalise_side(tres$side)
     tres$dataset=n

--- a/R/partners.R
+++ b/R/partners.R
@@ -95,10 +95,14 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     tres=coconat:::standardise_partner_summary(tres)
     if("class" %in% colnames(tres))
       tres$class=harmonise_top_class_values(tres$class, n)
+    if("side" %in% colnames(tres))
+      tres$side=normalise_side(tres$side)
     if(nrow(tres)>0) {
       tres$dataset=n
+      tres$tissue=dataset_tissue(n)
     } else {
       tres$dataset=character()
+      tres$tissue=character()
       warning("no ", partners, " found for `", n, "` dataset.")
     }
     tres$pre_key=keys(tres, idcol="pre_id")

--- a/R/partners.R
+++ b/R/partners.R
@@ -38,7 +38,8 @@
 #' }
 cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
                         bind.rows=TRUE, MoreArgs=list(), keep.all=FALSE,
-                        use_superclass=getOption("coconatfly.use_superclass", FALSE)) {
+                        use_superclass=getOption("coconatfly.use_superclass", FALSE),
+                        harmonise_class=getOption("coconatfly.harmonise_class", FALSE)) {
   partners=match.arg(partners)
   threshold <- checkmate::assert_integerish(
     threshold, lower=0L,len = 1, null.ok = F, all.missing = F)
@@ -51,7 +52,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     ss=split(ids$id, ids$dataset)
     res=cf_partners(ss, threshold = threshold, partners = partners,
                     bind.rows = bind.rows, MoreArgs=MoreArgs,
-                    use_superclass=use_superclass)
+                    use_superclass=use_superclass, harmonise_class=harmonise_class)
     return(res)
   }
 
@@ -93,7 +94,7 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     tres <- add_partner_metadata(tres, dataset = n, partners = partners)
 
     tres=coconat:::standardise_partner_summary(tres)
-    if("class" %in% colnames(tres))
+    if(isTRUE(harmonise_class) && "class" %in% colnames(tres))
       tres$class=harmonise_top_class_values(tres$class, n)
     if("side" %in% colnames(tres))
       tres$side=normalise_side(tres$side)

--- a/R/partners.R
+++ b/R/partners.R
@@ -100,9 +100,11 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     if(nrow(tres)>0) {
       tres$dataset=n
       tres$tissue=dataset_tissue(n)
+      tres$sex=dataset_sex(n)
     } else {
       tres$dataset=character()
       tres$tissue=character()
+      tres$sex=character()
       warning("no ", partners, " found for `", n, "` dataset.")
     }
     tres$pre_key=keys(tres, idcol="pre_id")

--- a/R/partners.R
+++ b/R/partners.R
@@ -93,6 +93,8 @@ cf_partners <- function(ids, threshold=1L, partners=c("inputs", "outputs"),
     tres <- add_partner_metadata(tres, dataset = n, partners = partners)
 
     tres=coconat:::standardise_partner_summary(tres)
+    if("class" %in% colnames(tres))
+      tres$class=harmonise_top_class_values(tres$class, n)
     if(nrow(tres)>0) {
       tres$dataset=n
     } else {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,6 +9,7 @@ register_builtin_datasets <- function() {
     idfun = .flywire_ids,
     partnerfun = .flywire_partners,
     shortname = "fw",
+    sex = "F",
     namespace = "coconatfly"
   )
 
@@ -18,6 +19,7 @@ register_builtin_datasets <- function() {
     idfun = .hemibrain_ids,
     partnerfun = .hemibrain_partners,
     shortname = "hb",
+    sex = "F",
     namespace = "coconatfly"
   )
 
@@ -27,6 +29,7 @@ register_builtin_datasets <- function() {
     idfun = .opticlobe_ids,
     partnerfun = .opticlobe_partners,
     shortname = "ol",
+    sex = "M",
     namespace = "coconatfly"
   )
 
@@ -36,6 +39,7 @@ register_builtin_datasets <- function() {
     idfun = .malecns_ids,
     partnerfun = .malecns_partners,
     shortname = "mc",
+    sex = "M",
     namespace = "coconatfly"
   )
 
@@ -45,6 +49,7 @@ register_builtin_datasets <- function() {
     idfun = .manc_ids,
     partnerfun = .manc_partners,
     shortname = "mv",
+    sex = "M",
     namespace = "coconatfly"
   )
 
@@ -54,6 +59,7 @@ register_builtin_datasets <- function() {
     idfun = .fanc_ids,
     partnerfun = .fanc_partners,
     shortname = "fv",
+    sex = "F",
     namespace = "coconatfly"
   )
 
@@ -63,6 +69,7 @@ register_builtin_datasets <- function() {
     idfun = .banc_ids,
     partnerfun = .banc_partners,
     shortname = "bc",
+    sex = "F",
     namespace = "coconatfly"
   )
 
@@ -72,6 +79,7 @@ register_builtin_datasets <- function() {
     idfun = .yakubavnc_ids,
     partnerfun = .yakubavnc_partners,
     shortname = "yv",
+    sex = "M",
     namespace = "coconatfly"
   )
 }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -34,6 +34,7 @@ articles:
 - title: All vignettes
   contents:
   - getting-started
+  - metadata-columns
   - TuTu
   - AOTU063
   - extending-coconatfly

--- a/man/cf_meta.Rd
+++ b/man/cf_meta.Rd
@@ -10,6 +10,7 @@ cf_meta(
   integer64 = FALSE,
   keep.all = FALSE,
   use_superclass = getOption("coconatfly.use_superclass", FALSE),
+  harmonise_class = getOption("coconatfly.harmonise_class", FALSE),
   MoreArgs = list(flywire = list(type = c("cell_type", "hemibrain_type")))
 )
 }
@@ -33,6 +34,10 @@ columns).}
 \item{use_superclass}{If \code{TRUE}, rename class/subclass/subsubclass
 columns to superclass/class/subclass. Can also be set via the
 \code{coconatfly.use_superclass} option.}
+
+\item{harmonise_class}{If \code{TRUE}, harmonise class values to malecns
+style across all datasets. Can also be set via the
+\code{coconatfly.harmonise_class} option.}
 
 \item{MoreArgs}{A named list of arguments to be passed when fetching metadata
 for a given function. See details.}

--- a/man/cf_meta.Rd
+++ b/man/cf_meta.Rd
@@ -41,8 +41,21 @@ for a given function. See details.}
 Fetch metadata for neurons from connectome datasets
 }
 \details{
+The returned data frame includes these standard columns:
+\itemize{
+  \item \code{id}, \code{key}: neuron identifiers (key is unique across datasets)
+  \item \code{class}, \code{subclass}, \code{type}: cell class hierarchy
+    (harmonised to malecns style across datasets)
+  \item \code{instance}: summarises properties of individual neurons
+  \item \code{side}: normalised to L/R/M (left/right/midline) or NA
+  \item \code{sex}: M or F, from dataset registration
+  \item \code{tissue}: brain, vnc, or cns depending on dataset
+  \item \code{group}: numeric, defines related neurons within dataset
+  \item \code{dataset}: source dataset name
+}
+
 \code{MoreArgs} is structured as a list with a top layer naming datasets
-  (using the same long names as \code{\link{cf_datasets}}. The second (lower)
+  (using the same long names as \code{\link{cf_datasets}}). The second (lower)
   layer names the arguments that will be passed to dataset-specific functions.
 }
 \examples{

--- a/man/cf_partners.Rd
+++ b/man/cf_partners.Rd
@@ -11,7 +11,8 @@ cf_partners(
   bind.rows = TRUE,
   MoreArgs = list(),
   keep.all = FALSE,
-  use_superclass = getOption("coconatfly.use_superclass", FALSE)
+  use_superclass = getOption("coconatfly.use_superclass", FALSE),
+  harmonise_class = getOption("coconatfly.harmonise_class", FALSE)
 )
 }
 \arguments{
@@ -38,6 +39,10 @@ columns).}
 \item{use_superclass}{If \code{TRUE}, rename class/subclass/subsubclass
 columns to superclass/class/subclass. Can also be set via the
 \code{coconatfly.use_superclass} option.}
+
+\item{harmonise_class}{If \code{TRUE}, harmonise class values to malecns
+style across all datasets. Can also be set via the
+\code{coconatfly.harmonise_class} option.}
 }
 \value{
 A data.frame or a named list (when \code{bind.rows=FALSE})

--- a/man/coconatfly-package.Rd
+++ b/man/coconatfly-package.Rd
@@ -16,6 +16,9 @@ Experimental package to enable comparative connectomics analysis of multiple Dro
   \code{\link{cf_meta}}, \code{\link{cf_partners}}, and
   \code{\link{cf_partner_summary}}. Default: \code{FALSE}.
   Set with \code{options(coconatfly.use_superclass = TRUE)}.}
+  \item{\code{coconatfly.harmonise_class}}{Logical. If \code{TRUE}, harmonise
+  class values to malecns style across all datasets. Default: \code{FALSE}.
+  Set with \code{options(coconatfly.harmonise_class = TRUE)}.}
 }
 }
 

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -18,6 +18,36 @@ test_that("coconatfly.use_superclass option works", {
   expect_true("superclass" %in% colnames(meta))
 })
 
+test_that("side values are normalised to L/R/M/NA", {
+  expect_equal(normalise_side(c("left", "L", "l", "LEFT")), c("L", "L", "L", "L"))
+  expect_equal(normalise_side(c("right", "R", "r", "RIGHT")), c("R", "R", "R", "R"))
+  expect_equal(normalise_side(c("midline", "M", "m", "center", "centre")),
+               c("M", "M", "M", "M", "M"))
+  expect_equal(normalise_side(c(NA, "", "unknown")),
+               c(NA_character_, NA_character_, NA_character_))
+})
+
+test_that("tissue column is based on dataset", {
+  expect_equal(dataset_tissue("flywire"), "brain")
+  expect_equal(dataset_tissue("hemibrain"), "brain")
+  expect_equal(dataset_tissue("opticlobe"), "brain")
+  expect_equal(dataset_tissue("manc"), "vnc")
+  expect_equal(dataset_tissue("fanc"), "vnc")
+  expect_equal(dataset_tissue("yakubavnc"), "vnc")
+  expect_equal(dataset_tissue("malecns"), "cns")
+  expect_equal(dataset_tissue("banc"), "cns")
+  expect_equal(dataset_tissue("unknown"), NA_character_)
+})
+
+test_that("cf_meta includes tissue column and normalised side", {
+  meta <- cf_meta(cf_ids(hemibrain = "MBON01"))
+  expect_true("tissue" %in% colnames(meta))
+  expect_true("side" %in% colnames(meta))
+  expect_equal(unique(meta$tissue), "brain")
+  # hemibrain MBON01 should have R/L sides
+  expect_true(all(meta$side %in% c("L", "R", "M", NA_character_)))
+})
+
 test_that("top-level class values are harmonised to malecns style", {
   ds <- c(
     rep("flywire", 10),

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -39,11 +39,19 @@ test_that("tissue column is based on dataset", {
   expect_equal(dataset_tissue("unknown"), NA_character_)
 })
 
-test_that("cf_meta includes tissue column and normalised side", {
+test_that("sex column comes from dataset registration", {
+  expect_equal(dataset_sex("hemibrain"), "F")
+  expect_equal(dataset_sex("malecns"), "F")
+  expect_equal(dataset_sex("manc"), "M")
+})
+
+test_that("cf_meta includes tissue, sex, and normalised side", {
   meta <- cf_meta(cf_ids(hemibrain = "MBON01"))
   expect_true("tissue" %in% colnames(meta))
+  expect_true("sex" %in% colnames(meta))
   expect_true("side" %in% colnames(meta))
   expect_equal(unique(meta$tissue), "brain")
+  expect_equal(unique(meta$sex), "F")
   # hemibrain MBON01 should have R/L sides
   expect_true(all(meta$side %in% c("L", "R", "M", NA_character_)))
 })

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -18,6 +18,76 @@ test_that("coconatfly.use_superclass option works", {
   expect_true("superclass" %in% colnames(meta))
 })
 
+test_that("top-level class values are harmonised to malecns style", {
+  ds <- c(
+    rep("flywire", 10),
+    rep("manc", 8),
+    "malecns",
+    "flywire",
+    "manc",
+    "banc"
+  )
+  cls <- c(
+    "ascending",
+    "descending",
+    "central",
+    "sensory",
+    "sensory_ascending",
+    "visual_projection",
+    "visual_centrifugal",
+    "endocrine",
+    "motor",
+    "optic",  # flywire optic -> ol_intrinsic
+    "ascending neuron",
+    "descending neuron",
+    "sensory neuron",
+    "sensory ascending",
+    "sensory descending",
+    "efferent neuron",
+    "efferent ascending",
+    "intrinsic neuron",
+    "descending_neuron",
+    "not_a_known_class",
+    "not_a_known_class",
+    "Sensory TBD"
+  )
+  expect <- c(
+    "ascending_neuron",
+    "descending_neuron",
+    "cb_intrinsic",
+    "cb_sensory",
+    "sensory_ascending",
+    "visual_projection",
+    "visual_centrifugal",
+    "endocrine",
+    "cb_motor",
+    "ol_intrinsic",  # flywire optic -> ol_intrinsic
+    "ascending_neuron",
+    "descending_neuron",
+    "vnc_sensory",
+    "sensory_ascending",
+    "sensory_descending",
+    "vnc_efferent",
+    "efferent_ascending",
+    "vnc_intrinsic",
+    "descending_neuron",
+    "not_a_known_class",
+    "not_a_known_class",
+    "Sensory TBD"  # banc skipped for now, passed through unchanged
+  )
+  expect_equal(harmonise_top_class_values(cls, ds), expect)
+
+  expect_equal(
+    harmonise_top_class_values("not_a_known_class", "flywire", unknown_as_na = TRUE),
+    NA_character_
+  )
+
+  expect_equal(
+    harmonise_top_class_values("descending_neuron", "malecns", unknown_as_na = TRUE),
+    "descending_neuron"
+  )
+})
+
 test_that("metadata", {
 
   expect_warning(
@@ -64,5 +134,3 @@ test_that("extra datasets", {
   # badrhubarb has no idfun, so cf_ids errors when trying to expand (the new default)
   expect_error(cf_ids(badrhubarb=10001))
 })
-
-

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -41,7 +41,7 @@ test_that("tissue column is based on dataset", {
 
 test_that("sex column comes from dataset registration", {
   expect_equal(dataset_sex("hemibrain"), "F")
-  expect_equal(dataset_sex("malecns"), "F")
+  expect_equal(dataset_sex("malecns"), "M")
   expect_equal(dataset_sex("manc"), "M")
 })
 
@@ -54,6 +54,27 @@ test_that("cf_meta includes tissue, sex, and normalised side", {
   expect_equal(unique(meta$sex), "F")
   # hemibrain MBON01 should have R/L sides
   expect_true(all(meta$side %in% c("L", "R", "M", NA_character_)))
+})
+
+test_that("coconatfly.harmonise_class option works", {
+  skip_if_not_installed('malevnc')
+  old_opt <- getOption("coconatfly.harmonise_class")
+  on.exit(options(coconatfly.harmonise_class = old_opt))
+
+  # Without harmonisation, manc and malecns have different class values
+  options(coconatfly.harmonise_class = FALSE)
+  meta_off <- cf_meta(cf_ids(manc = "AN07B004", malecns = "AN07B004"))
+  manc_class <- unique(meta_off$class[meta_off$dataset == "manc"])
+  malecns_class <- unique(meta_off$class[meta_off$dataset == "malecns"])
+  # manc uses "ascending neuron", malecns uses "ascending_neuron"
+  expect_false(identical(manc_class, malecns_class))
+
+  # With harmonisation enabled, classes should match
+  options(coconatfly.harmonise_class = TRUE)
+  meta_on <- cf_meta(cf_ids(manc = "AN07B004", malecns = "AN07B004"))
+  manc_class_h <- unique(meta_on$class[meta_on$dataset == "manc"])
+  malecns_class_h <- unique(meta_on$class[meta_on$dataset == "malecns"])
+  expect_equal(manc_class_h, malecns_class_h)
 })
 
 test_that("top-level class values are harmonised to malecns style", {

--- a/vignettes/metadata-columns.Rmd
+++ b/vignettes/metadata-columns.Rmd
@@ -1,0 +1,185 @@
+---
+title: "2. Metadata columns and harmonisation"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{2. Metadata columns and harmonisation}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Introduction
+
+When querying metadata across multiple connectome datasets with `cf_meta()`,
+*coconatfly* returns a standardised set of columns. This vignette documents these
+columns and explains how values are harmonised across datasets.
+
+```{r setup, message=FALSE}
+library(coconatfly)
+library(dplyr)
+```
+
+## Standard columns
+
+The `cf_meta()` function returns these standard columns:
+
+| Column | Description |
+|--------|-------------|
+| `id` | Neuron identifier (dataset-specific) |
+| `key` | Unique identifier across all datasets (format: `dataset:id`) |
+| `dataset` | Source dataset name |
+| `class` | Top-level cell class (optionally harmonised) |
+| `subclass` | Cell subclass |
+| `type` | Cell type name, the finest classification level |
+| `instance` | Individual neuron properties (typically formatted as `{type}_{side}`) |
+| `side` | Normalised to L/R/M (left/right/midline) or NA |
+| `sex` | M or F, based on the dataset |
+| `tissue` | brain, vnc, or cns depending on dataset |
+| `group` | Numeric grouping of related neurons within dataset |
+
+### Example: MBON01 across datasets
+
+```{r mbon01}
+mbon01 <- cf_meta(cf_ids("MBON01", datasets = c("flywire", "malecns")))
+mbon01 %>%
+  select(id, class, type, side, sex, tissue, dataset, key)
+```
+
+## Dataset properties
+
+### Sex
+
+The `sex` column reflects the sex of the animal from which the dataset was
+derived:
+
+| Dataset | Sex | Description |
+|---------|-----|-------------|
+| flywire | F | Female adult brain |
+| hemibrain | F | Female adult brain |
+| opticlobe | M | Male optic lobe |
+| malecns | M | Male central nervous system |
+| manc | M | Male adult nerve cord |
+| fanc | F | Female adult nerve cord |
+| banc | F | Female adult nerve cord |
+| yakubavnc | M | Male D. yakuba VNC |
+
+### Tissue
+
+The `tissue` column indicates the region of the nervous system:
+
+- `brain`: Brain datasets (flywire, hemibrain, opticlobe)
+- `vnc`: Ventral nerve cord datasets (manc, fanc, yakubavnc)
+- `cns`: Complete CNS datasets (malecns, banc)
+
+## Side normalisation
+
+The `side` column is normalised to single uppercase letters:
+
+- `L`: Left
+- `R`: Right
+- `M`: Midline (or center)
+- `NA`: Unknown or not applicable
+
+Input values like "left", "Left", "L", "l" are all normalised to "L".
+
+## Superclass/class field names
+
+Most datasets have a multi-level annotation hierarchy from very broad terms to 
+terminal cell types, which represent the finest level of conservation across
+datasets. Different datasets use different conventions for names and values of 
+these fields. We have already noted that `type` is our default name for the 
+finest level classification. The flywire data model calls this `cell_type` but
+we always remap the column name to type.
+
+For malecns, the top level in the `class` hierarchy is `superclass`, while
+flywire uses `super_class` and manc uses `class`. For historical reasons,
+the default is to rename all of these to `class`.
+You can opt to have the top level column as `superclass`. The renaming can be
+controlled by the `coconatfly.use_superclass` package option. 
+
+```{r superclass, eval=FALSE}
+options(coconatfly.use_superclass = TRUE)
+# or
+cf_meta(ids, use_superclass = TRUE)
+```
+
+This currently
+defaults to FALSE, but we expect a future version to use this by default, more
+closely emulating the male cns.
+
+- `class` -> `superclass` (values like ascending_neuron)
+- `subclass` -> `class` (values like ALPN)
+- `subsubclass` -> `subclass`
+
+## Class harmonisation
+
+Even when the columns have the same name, values may differ. For example, 
+ascending neurons that project from the VNC to the brain might be labelled:
+
+- malecns: `ascending_neuron`
+- manc: `ascending neuron`
+- flywire: `ascending`
+
+in different datasets.
+
+### Enabling harmonisation
+
+By default, class values are **not** harmonised, preserving the original
+values in each dataset. To enable harmonisation to malecns-style values,
+use the `harmonise_class` parameter or set a global option:
+
+```{r harmonise-param-options, eval=FALSE}
+cf_meta(ids, harmonise_class = TRUE)
+
+options(coconatfly.harmonise_class = TRUE)
+cf_meta(ids)
+```
+
+A future version of coconatfly will make harmonisation the default.
+
+### Example: Ascending neurons
+
+Without harmonisation, class values differ between datasets:
+```{r an-no-harmonise}
+an_meta <- cf_meta(cf_ids("AN07B004", datasets = c("manc", "malecns")))
+an_meta %>%
+  select(type, class, side, dataset)
+```
+
+With harmonisation enabled:
+```{r an-harmonise}
+an_meta_h <- cf_meta(cf_ids("AN07B004", datasets = c("manc", "malecns")),
+                     harmonise_class = TRUE)
+an_meta_h %>%
+  select(type, class, side, dataset)
+```
+
+### Harmonisation rules
+
+When `harmonise_class = TRUE`, class values are mapped to malecns conventions:
+
+| Pattern | Harmonised value |
+|---------|------------------|
+| ascending (+ neuron) | ascending_neuron |
+| descending (+ neuron) | descending_neuron |
+| sensory + ascending | sensory_ascending |
+| sensory + descending | sensory_descending |
+| efferent + ascending | efferent_ascending |
+| sensory | {domain}_sensory |
+| motor | {domain}_motor |
+| intrinsic, central | {domain}_intrinsic |
+| efferent | {domain}_efferent |
+| optic | ol_intrinsic |
+| visual projection | visual_projection |
+| visual centrifugal | visual_centrifugal |
+| endocrine | endocrine |
+
+Where `{domain}` is `cb` (central brain), `vnc`, or `ol` (optic lobe) based on
+the dataset.
+


### PR DESCRIPTION
## Summary
- Add optional class harmonisation to malecns style (controlled by `coconatfly.harmonise_class` option)
- Add `tissue` column (brain/vnc/cns) based on dataset
- Add `sex` column (M/F) from dataset registration
- Normalise `side` values to L/R/M/NA
- Document standard columns in `cf_meta()`

## New package options
- `coconatfly.harmonise_class`: If TRUE, harmonise class values to malecns style across all datasets (default: FALSE)

## Standard columns
The returned data frame now includes these standard columns:
- `id`, `key`: neuron identifiers (key is unique across datasets)
- `class`, `subclass`, `type`: cell class hierarchy (optionally harmonised to malecns style)
- `instance`: summarises properties of individual neurons
- `side`: normalised to L/R/M (left/right/midline) or NA
- `sex`: M or F, from dataset registration
- `tissue`: brain, vnc, or cns depending on dataset
- `group`: numeric, defines related neurons within dataset
- `dataset`: source dataset name

## Related
- Depends on https://github.com/natverse/coconat/pull/10 (warning for missing sex in register_dataset)

🤖 Generated with [Claude Code](https://claude.ai/code)